### PR TITLE
Add drop_last=True to the DataLoader

### DIFF
--- a/src/diffwave/dataset.py
+++ b/src/diffwave/dataset.py
@@ -82,4 +82,5 @@ def from_path(data_dirs, params, is_distributed=False):
       collate_fn=Collator(params).collate,
       shuffle=not is_distributed,
       num_workers=os.cpu_count(),
-      sampler=DistributedSampler(dataset) if is_distributed else None)
+      sampler=DistributedSampler(dataset) if is_distributed else None,
+      drop_last=True)


### PR DESCRIPTION
This prevents a crash at the end of an epoch where the number of samples isn't divisible by the batch size.